### PR TITLE
fix(sec): upgrade com.alibaba:fastjson to 1.2.83

### DIFF
--- a/springboot-action-sample/pom.xml
+++ b/springboot-action-sample/pom.xml
@@ -118,7 +118,7 @@
 	  	<dependency>
 	   	  	<groupId>com.alibaba</groupId>
 	   	  	<artifactId>fastjson</artifactId>
-	   	  	<version>1.2.6</version>
+	   	  	<version>1.2.83</version>
 	  	</dependency>
 	  	<dependency>
 	        <groupId>com.fasterxml.jackson.core</groupId>

--- a/springboot-action-web/pom.xml
+++ b/springboot-action-web/pom.xml
@@ -58,7 +58,7 @@
 	  	<dependency>
 	   	  	<groupId>com.alibaba</groupId>
 	   	  	<artifactId>fastjson</artifactId>
-	   	  	<version>1.2.6</version>
+	   	  	<version>1.2.83</version>
 	  	</dependency>
 	  	<dependency>
 	        <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.alibaba:fastjson 1.2.6
- [CVE-2022-25845](https://www.oscs1024.com/hd/CVE-2022-25845)


### What did I do？
Upgrade com.alibaba:fastjson from 1.2.6 to 1.2.83 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS