### PR TITLE
fix(sec): upgrade com.google.guava:guava to 30.0-jre

### DIFF
--- a/springboot-action-cache/pom.xml
+++ b/springboot-action-cache/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>19.0</version>
+			<version>32.0.0-jre</version>
 		</dependency>
 		
 		<!--  


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.guava:guava 19.0
- [CVE-2018-10237](https://www.oscs1024.com/hd/CVE-2018-10237)


### What did I do？
Upgrade com.google.guava:guava from 19.0 to 30.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS